### PR TITLE
pm: introduce persistent memory support

### DIFF
--- a/include/__hash_table
+++ b/include/__hash_table
@@ -74,8 +74,9 @@ struct __hash_node
              >
 {
     typedef _Tp __node_value_type;
+    typedef typename __rebind_persistency_type<_VoidPtr, size_t>::type size_type;
 
-    size_t     __hash_;
+    size_type     __hash_;
     __node_value_type __value_;
 };
 
@@ -803,11 +804,12 @@ class __bucket_list_deallocator
 {
     typedef _Alloc                                          allocator_type;
     typedef allocator_traits<allocator_type>                __alloc_traits;
-    typedef typename __alloc_traits::size_type              size_type;
-
-    __compressed_pair<size_type, allocator_type> __data_;
 public:
     typedef typename __alloc_traits::pointer pointer;
+private:
+    typedef typename __rebind_persistency_type<pointer, typename __alloc_traits::size_type>::type size_type;
+    __compressed_pair<size_type, allocator_type> __data_;
+public:
 
     _LIBCPP_INLINE_VISIBILITY
     __bucket_list_deallocator()
@@ -911,11 +913,14 @@ public:
     typedef typename __alloc_traits::pointer         pointer;
     typedef typename __alloc_traits::const_pointer   const_pointer;
 #ifndef _LIBCPP_ABI_FIX_UNORDERED_CONTAINER_SIZE_TYPE
-    typedef typename __alloc_traits::size_type       size_type;
+    typedef typename __alloc_traits::size_type       raw_size_type;
 #else
-    typedef typename _NodeTypes::size_type           size_type;
+    typedef typename _NodeTypes::size_type           raw_size_type;
 #endif
-    typedef typename _NodeTypes::difference_type     difference_type;
+    typedef typename _NodeTypes::difference_type     raw_difference_type;
+
+    typedef typename __rebind_persistency_type<pointer, raw_difference_type>::type difference_type;
+    typedef typename __rebind_persistency_type<pointer, raw_size_type>::type size_type;
 public:
     // Create __node
 

--- a/include/__tree
+++ b/include/__tree
@@ -726,9 +726,11 @@ public:
     typedef typename _NodeBaseTypes::__node_base_pointer pointer;
     typedef typename _NodeBaseTypes::__parent_pointer __parent_pointer;
 
+    typedef typename __rebind_persistency_type<pointer, bool>::type bool_type;
+
     pointer          __right_;
     __parent_pointer __parent_;
-    bool __is_black_;
+    bool_type __is_black_;
 
     _LIBCPP_INLINE_VISIBILITY
     pointer __parent_unsafe() const { return static_cast<pointer>(__parent_);}
@@ -975,8 +977,8 @@ public:
 
     typedef typename __alloc_traits::pointer         pointer;
     typedef typename __alloc_traits::const_pointer   const_pointer;
-    typedef typename __alloc_traits::size_type       size_type;
-    typedef typename __alloc_traits::difference_type difference_type;
+    typedef typename __rebind_persistency_type<pointer, typename __alloc_traits::difference_type>::type difference_type;
+    typedef typename __rebind_persistency_type<pointer, typename __alloc_traits::size_type>::type size_type;
 
 public:
     typedef typename _NodeTypes::__void_pointer        __void_pointer;

--- a/include/deque
+++ b/include/deque
@@ -929,10 +929,12 @@ protected:
     typedef allocator_traits<allocator_type>         __alloc_traits;
     typedef value_type&                              reference;
     typedef const value_type&                        const_reference;
-    typedef typename __alloc_traits::size_type       size_type;
-    typedef typename __alloc_traits::difference_type difference_type;
     typedef typename __alloc_traits::pointer         pointer;
     typedef typename __alloc_traits::const_pointer   const_pointer;
+    typedef typename __alloc_traits::size_type       raw_size_type;
+    typedef typename __rebind_persistency_type<pointer, raw_size_type>::type size_type;
+    typedef typename __alloc_traits::difference_type raw_difference_type;
+    typedef typename __rebind_persistency_type<pointer, raw_difference_type>::type difference_type;
 
     static const difference_type __block_size;
 

--- a/include/deque
+++ b/include/deque
@@ -939,8 +939,7 @@ protected:
     typedef typename __rebind_alloc_helper<__alloc_traits, pointer>::type __pointer_allocator;
     typedef allocator_traits<__pointer_allocator>        __map_traits;
     typedef typename __map_traits::pointer               __map_pointer;
-    typedef typename __rebind_alloc_helper<__alloc_traits, const_pointer>::type __const_pointer_allocator;
-    typedef typename allocator_traits<__const_pointer_allocator>::const_pointer __map_const_pointer;
+    typedef typename allocator_traits<__pointer_allocator>::const_pointer __map_const_pointer;
     typedef __split_buffer<pointer, __pointer_allocator> __map;
 
     typedef __deque_iterator<value_type, pointer, reference, __map_pointer,

--- a/include/list
+++ b/include/list
@@ -529,7 +529,6 @@ protected:
     typedef _Tp                                                     value_type;
     typedef _Alloc                                                  allocator_type;
     typedef allocator_traits<allocator_type>                        __alloc_traits;
-    typedef typename __alloc_traits::size_type                      size_type;
     typedef typename __alloc_traits::void_pointer                   __void_pointer;
     typedef __list_iterator<value_type, __void_pointer>             iterator;
     typedef __list_const_iterator<value_type, __void_pointer>       const_iterator;
@@ -544,10 +543,14 @@ protected:
     typedef __link_pointer __link_const_pointer;
     typedef typename __alloc_traits::pointer                         pointer;
     typedef typename __alloc_traits::const_pointer                   const_pointer;
-    typedef typename __alloc_traits::difference_type                 difference_type;
 
     typedef typename __rebind_alloc_helper<__alloc_traits, __node_base>::type __node_base_allocator;
     typedef typename allocator_traits<__node_base_allocator>::pointer __node_base_pointer;
+
+    typedef typename __alloc_traits::size_type       raw_size_type;
+    typedef typename __alloc_traits::difference_type       raw_difference_type;
+    typedef typename __rebind_persistency_type<pointer, raw_size_type>::type size_type;
+    typedef typename __rebind_persistency_type<pointer, raw_difference_type>::type difference_type;
 
     __node_base __end_;
     __compressed_pair<size_type, __node_allocator> __size_alloc_;

--- a/include/map
+++ b/include/map
@@ -849,12 +849,15 @@ private:
 public:
     typedef typename __alloc_traits::pointer               pointer;
     typedef typename __alloc_traits::const_pointer         const_pointer;
-    typedef typename __alloc_traits::size_type             size_type;
-    typedef typename __alloc_traits::difference_type       difference_type;
     typedef __map_iterator<typename __base::iterator>             iterator;
     typedef __map_const_iterator<typename __base::const_iterator> const_iterator;
     typedef _VSTD::reverse_iterator<iterator>               reverse_iterator;
     typedef _VSTD::reverse_iterator<const_iterator>         const_reverse_iterator;
+
+    typedef typename __alloc_traits::size_type       raw_size_type;
+    typedef typename __alloc_traits::difference_type       raw_difference_type;
+    typedef typename __rebind_persistency_type<pointer, raw_size_type>::type size_type;
+    typedef typename __rebind_persistency_type<pointer, raw_difference_type>::type difference_type;
 
     _LIBCPP_INLINE_VISIBILITY
     map()

--- a/include/memory
+++ b/include/memory
@@ -778,6 +778,29 @@ struct __pointer_traits_difference_type<_Ptr, true>
     typedef typename _Ptr::difference_type type;
 };
 
+template <class _Ptr>
+struct __has_persistency_type
+{
+private:
+    struct __two {char __lx; char __lxx;};
+    template <class _Up> static __two __test(...);
+    template <class _Up> static char __test(typename _Up::persistency_type* = 0);
+public:
+    static const bool value = sizeof(__test<_Ptr>(0)) == 1;
+};
+
+template <class _Tp, class _Ptr, bool = __has_persistency_type<_Ptr>::value>
+struct __pointer_traits_persistency_type
+{
+    typedef _Tp type;
+};
+
+template <class _Tp, class _Ptr>
+struct __pointer_traits_persistency_type<_Tp, _Ptr, true>
+{
+    typedef typename _Ptr::persistency_type type;
+};
+
 template <class _Tp, class _Up>
 struct __has_rebind
 {
@@ -895,6 +918,7 @@ struct _LIBCPP_TYPE_VIS_ONLY pointer_traits
     typedef _Ptr                                                     pointer;
     typedef typename __pointer_traits_element_type<pointer>::type    element_type;
     typedef typename __pointer_traits_difference_type<pointer>::type difference_type;
+    typedef typename __pointer_traits_persistency_type<element_type, pointer>::type persistency_type;
 
 #ifndef _LIBCPP_HAS_NO_TEMPLATE_ALIASES
     template <class _Up> using rebind = typename __pointer_traits_rebind<pointer, _Up>::type;
@@ -918,6 +942,7 @@ struct _LIBCPP_TYPE_VIS_ONLY pointer_traits<_Tp*>
     typedef _Tp*      pointer;
     typedef _Tp       element_type;
     typedef ptrdiff_t difference_type;
+    typedef _Tp       persistency_type;
 
 #ifndef _LIBCPP_HAS_NO_TEMPLATE_ALIASES
     template <class _Up> using rebind = _Up*;
@@ -941,6 +966,11 @@ struct __rebind_pointer {
 #else
     typedef typename pointer_traits<_From>::template rebind<_To>::other type;
 #endif
+};
+
+template<class _Ptr, class _Tp>
+struct __rebind_persistency_type {
+    typedef typename pointer_traits<typename __rebind_pointer<_Ptr, _Tp>::type>::persistency_type type;
 };
 
 // allocator_traits
@@ -1808,6 +1838,7 @@ class _LIBCPP_TYPE_VIS_ONLY allocator<const _Tp>
 public:
     typedef size_t            size_type;
     typedef ptrdiff_t         difference_type;
+    typedef const _Tp         persistency_type;
     typedef const _Tp*        pointer;
     typedef const _Tp*        const_pointer;
     typedef const _Tp&        reference;

--- a/include/set
+++ b/include/set
@@ -422,8 +422,13 @@ private:
 public:
     typedef typename __base::pointer               pointer;
     typedef typename __base::const_pointer         const_pointer;
-    typedef typename __base::size_type             size_type;
-    typedef typename __base::difference_type       difference_type;
+
+    typedef typename __alloc_traits::size_type              raw_size_type;
+    typedef typename __alloc_traits::difference_type        raw_difference_type;
+
+    typedef typename __rebind_persistency_type<pointer, raw_size_type>::type        size_type;
+    typedef typename __rebind_persistency_type<pointer, raw_difference_type>::type  difference_type;
+
     typedef typename __base::const_iterator        iterator;
     typedef typename __base::const_iterator        const_iterator;
     typedef _VSTD::reverse_iterator<iterator>       reverse_iterator;


### PR DESCRIPTION
This PR introduces experimental persistent memory support into the C++ standard library. The change is generic and can be used for different types of algorithms, not only for persistent memory. It defines a new optional type in the pointer traits that can be used to provide wrappers for non-pointer types related with the given pointer. This in turn can be used on internal container metadata. Please note that this is a non-standard and experimental feature. It most probably is not yet complete and needs more extensive testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libcxx/1)
<!-- Reviewable:end -->
