### PR TITLE
pm: remove unnecessary typedef

### DIFF
--- a/include/deque
+++ b/include/deque
@@ -933,8 +933,7 @@ protected:
     typedef typename __alloc_traits::const_pointer   const_pointer;
     typedef typename __alloc_traits::size_type       raw_size_type;
     typedef typename __rebind_persistency_type<pointer, raw_size_type>::type size_type;
-    typedef typename __alloc_traits::difference_type raw_difference_type;
-    typedef typename __rebind_persistency_type<pointer, raw_difference_type>::type difference_type;
+    typedef typename __alloc_traits::difference_type difference_type;
 
     static const difference_type __block_size;
 


### PR DESCRIPTION
std::deque does not need a rebind for difference_type. The way it is
used it is even impossible to rebind to a more complex type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libcxx/3)
<!-- Reviewable:end -->
