### PR TITLE
Fix libcxx build with glibc 2.26+ by removing xlocale.h include.

### DIFF
--- a/include/__locale
+++ b/include/__locale
@@ -34,7 +34,7 @@
 # include <support/solaris/xlocale.h>
 #elif defined(_NEWLIB_VERSION)
 # include <support/newlib/xlocale.h>
-#elif (defined(__GLIBC__) || defined(__APPLE__)      || defined(__FreeBSD__) \
+#elif (defined(__APPLE__)      || defined(__FreeBSD__) \
     || defined(__EMSCRIPTEN__) || defined(__IBMCPP__))
 # include <xlocale.h>
 #elif defined(_LIBCPP_HAS_MUSL_LIBC)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libcxx/4)
<!-- Reviewable:end -->
